### PR TITLE
Get the correct pull request to change

### DIFF
--- a/src/github.service.ts
+++ b/src/github.service.ts
@@ -41,7 +41,7 @@ export class GithubService {
       repo: this.repo,
       state: 'open',
       base,
-      head
+      head: `${this.owner}:${head}`
     });
 
     for (let i = 0; i < res.data.length; i++)


### PR DESCRIPTION
Previously it would get a list of all pull requests and use the first one instead of the specific one with the `head` we are looking for since the `head` needs to include the user (see https://octokit.github.io/rest.js/v17#pulls-list).

Fixes #20 